### PR TITLE
Fix: includeForks setting for bitbucket server

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -221,7 +221,7 @@ export async function initRepo({
     config.mergeMethod = 'merge';
     const repoConfig: RepoResult = {
       defaultBranch: branchRes.body.displayId,
-      isFork: !!info.parent,
+      isFork: !!info.origin,
     };
 
     return repoConfig;


### PR DESCRIPTION
Bitbucket server API response has 'origin' field in response instead of 'parent' if the repo is a fork

The api call https://<BITBUCKET_URL>/rest/api/1.0/projects/<PROJECT>/repos/<REPOSITORY> has no field called 'parent' but instead a 'origin' field.
Because of this issue, renovate is not able to identify if the repository is a fork which in turn breaks the 'includeForks': false setting.

<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
